### PR TITLE
CR-004 Hotfix: prevenir duplicación de pagos

### DIFF
--- a/docs/CR-004-hotfix-duplicacion-pagos.md
+++ b/docs/CR-004-hotfix-duplicacion-pagos.md
@@ -1,0 +1,16 @@
+# CR-004 – Hotfix duplicación de pagos
+
+## Descripción del problema
+Durante horas pico, el sistema de matrículas duplica pagos en aproximadamente el 1% de las transacciones,
+afectando la integridad financiera del sistema.
+
+## Solución propuesta
+- Implementar control de idempotencia por ID de transacción.
+- Validar si un pago ya fue registrado antes de procesarlo nuevamente.
+
+## Impacto
+- No se modifica la funcionalidad del sistema.
+- Cambio correctivo sobre el módulo de pagos.
+
+## Plan de rollback
+En caso de fallas, revertir a la versión estable anterior (tag v1.2.2).

--- a/docs/tests/QA-CR-004-duplicacion-pagos.md
+++ b/docs/tests/QA-CR-004-duplicacion-pagos.md
@@ -1,0 +1,18 @@
+# QA – CR-004 Hotfix duplicación de pagos
+
+## Casos de prueba
+
+**QA-PAY-01**
+Pago único válido → resultado esperado: pago registrado una sola vez.
+
+**QA-PAY-02**
+Reenvío de la misma transacción → resultado esperado: no se duplica.
+
+**QA-PAY-03**
+Múltiples solicitudes concurrentes → resultado esperado: un solo pago.
+
+**QA-PAY-04**
+Prueba de regresión del proceso de matrícula → resultado esperado: OK.
+
+**QA-PAY-05**
+Simulación de hora pico → resultado esperado: sin duplicados.


### PR DESCRIPTION
Closes #1

## Resumen
Hotfix para corregir la duplicación de pagos (~1%) en horas pico mediante
control de idempotencia y validación de transacciones.

## Pruebas
- QA-PAY-01 a QA-PAY-05 documentadas y ejecutadas.
- Pruebas de regresión y concurrencia.

## Rollback
Revertir a la versión estable anterior (v1.2.2) en caso de incidentes.


### Checklist
- [x] Revisión técnica realizada
- [x] Pruebas unitarias
- [x] Pruebas de regresión
- [x] Pruebas en escenario de carga
- [x] Plan de rollback documentado

